### PR TITLE
fix: move DevFest 2025 to top as most recent event

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,6 +378,54 @@
 
 			<h2 id="past-in-person-events">Past In-person Events</h2>
 			<div class="event">
+				<h3>DevFest Mumbai 2025</h3>
+				<div class="event-date">20th December 2025</div>
+
+				<p>
+					OTC was proud to be a 
+					<a
+						href="https://x.com/gdgmad/status/2001306435141988499"
+						target="_blank"
+						rel="noreferrer"
+						>Community Partner</a
+					>
+					for
+					<a
+						href="https://gdg.community.dev/events/details/google-gdg-mad-presents-devfest-mumbai-2025"
+						target="_blank"
+						rel="noreferrer"
+						>GDG DevFest Mumbai 2025</a
+					>. The event featured engaging talks and an enthusiastic 
+					crowd of developers and tech enthusiasts. It was great being 
+					part of such a vibrant community experience, with fun moments 
+					like the Tech Housie game.
+				</p>
+
+				<div class="event-grid">
+					<img
+						src="static/img/devfest-mumbai-20-12-2025/1.jpeg"
+						alt="Devfest Mumbai 2025"
+						loading="lazy"
+					/>
+					<img
+						src="static/img/devfest-mumbai-20-12-2025/2.jpeg"
+						alt="Devfest Mumbai 2025"
+						loading="lazy"
+					/>
+					<img
+						src="static/img/devfest-mumbai-20-12-2025/3.jpeg"
+						alt="Tech Housie Game - Devfest Mumbai 2025"
+						loading="lazy"
+					/>
+					<img
+						src="static/img/devfest-mumbai-20-12-2025/4.jpeg"
+						alt="Tech Housie Game - Devfest Mumbai 2025"
+						loading="lazy"
+					/>
+				</div>
+			</div>
+			
+			<div class="event">
 				<h3>Technical Writing Meetup</h3>
 				<div class="event-date">18th May 2025</div>
 
@@ -597,54 +645,6 @@
 					<img
 						src="static/img/womens-day-mumbai-2023/2.jpg"
 						alt="People discussing"
-						loading="lazy"
-					/>
-				</div>
-			</div>
-
-			<div class="event">
-				<h3>DevFest Mumbai 2025</h3>
-				<div class="event-date">20th December 2025</div>
-
-				<p>
-					OTC was proud to be a 
-					<a
-						href="https://x.com/gdgmad/status/2001306435141988499"
-						target="_blank"
-						rel="noreferrer"
-						>Community Partner</a
-					>
-					for
-					<a
-						href="https://gdg.community.dev/events/details/google-gdg-mad-presents-devfest-mumbai-2025"
-						target="_blank"
-						rel="noreferrer"
-						>GDG DevFest Mumbai 2025</a
-					>. The event featured engaging talks and an enthusiastic 
-					crowd of developers and tech enthusiasts. It was great being 
-					part of such a vibrant community experience, with fun moments 
-					like the Tech Housie game.
-				</p>
-
-				<div class="event-grid">
-					<img
-						src="static/img/devfest-mumbai-20-12-2025/1.jpeg"
-						alt="Devfest Mumbai 2025"
-						loading="lazy"
-					/>
-					<img
-						src="static/img/devfest-mumbai-20-12-2025/2.jpeg"
-						alt="Devfest Mumbai 2025"
-						loading="lazy"
-					/>
-					<img
-						src="static/img/devfest-mumbai-20-12-2025/3.jpeg"
-						alt="Tech Housie Game - Devfest Mumbai 2025"
-						loading="lazy"
-					/>
-					<img
-						src="static/img/devfest-mumbai-20-12-2025/4.jpeg"
-						alt="Tech Housie Game - Devfest Mumbai 2025"
 						loading="lazy"
 					/>
 				</div>


### PR DESCRIPTION
<img width="1894" height="1010" alt="image" src="https://github.com/user-attachments/assets/69f5e8f9-d503-4dd3-a491-cbf1c98e957d" />

moved devfest to top